### PR TITLE
Allow custom response handler

### DIFF
--- a/restful.js
+++ b/restful.js
@@ -70,12 +70,12 @@ module.exports = function setup(mount, vfs, mountOptions) {
     if (mount[mount.length - 1] !== "/") mount += "/";
 
     var path = unescape(req.uri.pathname);
-        
+
     // no need to sanitize the url (remove ../..) the vfs layer has this
     // responsibility since it can do it better with realpath.
     if (path.substr(0, mount.length) !== mount) { return next(); }
     path = path.substr(mount.length - 1);
-    
+
     // Allow for proxy header.
     if (req.headers.hasOwnProperty("vfs-url")) {
       var base = req.headers['vfs-url'];
@@ -160,7 +160,10 @@ module.exports = function setup(mount, vfs, mountOptions) {
           meta.stream.on("error", abort);
           if (options.encoding === null) {
             jsonEncoder(meta.stream, base, htmlBase).pipe(res);
-          } else {
+          } else if (typeof mountOptions.responseWrapper === 'function'){
+            mountOptions.responseWrapper(meta.stream, res);
+          }
+          else {
             meta.stream.pipe(res);
           }
           req.on("close", function () {
@@ -291,7 +294,7 @@ module.exports = function setup(mount, vfs, mountOptions) {
             return abort(err);
           }
           processMessage(message);
-        });        
+        });
       } else {
         processMessage(req.body);
       }
@@ -310,4 +313,3 @@ module.exports = function setup(mount, vfs, mountOptions) {
   };
 
 };
-


### PR DESCRIPTION
This PR was motivated by a security need to have all files returned JSON
serialized as opposed to raw which exposed an XSS vulnerability. There needed
to be a way to return the full file payload to the response stream in a
way customized by the client. In our specific use case we willprovide a function
that wraps the buffer in json before piping out to the response, but there are other
possiblie scenarios that could occur down the line, hence making this very general
as opposed to a default json wrapper.

@tsaiy @apatil 

See also: PR in CDSW