### PR TITLE
[DSE-2456] return html as plain text

### DIFF
--- a/restful.js
+++ b/restful.js
@@ -70,12 +70,12 @@ module.exports = function setup(mount, vfs, mountOptions) {
     if (mount[mount.length - 1] !== "/") mount += "/";
 
     var path = unescape(req.uri.pathname);
-        
+
     // no need to sanitize the url (remove ../..) the vfs layer has this
     // responsibility since it can do it better with realpath.
     if (path.substr(0, mount.length) !== mount) { return next(); }
     path = path.substr(mount.length - 1);
-    
+
     // Allow for proxy header.
     if (req.headers.hasOwnProperty("vfs-url")) {
       var base = req.headers['vfs-url'];
@@ -161,6 +161,8 @@ module.exports = function setup(mount, vfs, mountOptions) {
           if (options.encoding === null) {
             jsonEncoder(meta.stream, base, htmlBase).pipe(res);
           } else {
+            //Force html responses to display raw
+            if(res.header()._headers["content-type"] === "text/html") res.setHeader("Content-Type", "text/plain");
             meta.stream.pipe(res);
           }
           req.on("close", function () {
@@ -291,7 +293,7 @@ module.exports = function setup(mount, vfs, mountOptions) {
             return abort(err);
           }
           processMessage(message);
-        });        
+        });
       } else {
         processMessage(req.body);
       }
@@ -310,4 +312,3 @@ module.exports = function setup(mount, vfs, mountOptions) {
   };
 
 };
-


### PR DESCRIPTION
To address the possibility of an XSS attack, we shouldn't
render html files within a project as html when they're being
accessed through the api /projects/files/file_name.html route.

Returning them as text/plain ensures no changes to the resulting
text, but don't render it in the browser. This seems to be similar
to what github does when you

The pen testers recommended solving this by wrapping files in json.
This is suitable for text only responses, but we use the same api mechanism
for serving images, binary files (if a user has them) etc. We will reach out
to the pen testers, but this does seem to accomplish the same goal without
risking any major breakage in our file serving process.

@tsaiy 